### PR TITLE
Byggde säkra endpoints  för uppladdning av kontrakter och anläggnings bilder till Azure Blob Storage

### DIFF
--- a/KonferenscentrumVast/Controllers/BookingContractController.cs
+++ b/KonferenscentrumVast/Controllers/BookingContractController.cs
@@ -146,6 +146,20 @@ namespace KonferenscentrumVast.Controllers
         }
 
         /// <summary>
+        /// Uploads a contract file and associates it with a contract
+        /// </summary>
+        /// <param name="file">The contract file (PDF and DOCX)</param>
+        /// <param name="contractId">ID of the contract this file belongs to</param>
+        /// <returns>Information about the uploaded file</returns>
+        [HttpPost("{contractId:int}/uploadcontract")]
+        [Consumes("multipart/form-data")]
+        public async Task<ActionResult<FileUploadResultDto>> UploadContract(IFormFile file, int contractId)
+        {
+            var result = await _service.UploadContractAsync(file, contractId);
+            return Ok(result);
+        }
+
+        /// <summary>
         /// Converts domain model to response DTO with flattened data for API consumers
         /// </summary>
         private static BookingContractResponseDto ToDto(BookingContract c)

--- a/KonferenscentrumVast/Controllers/FacilityController.cs
+++ b/KonferenscentrumVast/Controllers/FacilityController.cs
@@ -130,6 +130,20 @@ namespace KonferenscentrumVast.Controllers
             return Ok(ToDto(updated));
         }
 
+        /// <summary>
+        /// Uploads an image file and associates it with a facility
+        /// </summary>
+        /// <param name="file">The image file (JPG and PNG)</param>
+        /// <param name="facilityId">ID of the facility this file belongs to</param>
+        /// <returns>Information about the uploaded file</returns>
+        [HttpPost("{facilityId:int}/uploadimage")]
+        [Consumes("multipart/form-data")]
+        public async Task<ActionResult<FileUploadResultDto>> UploadImage(IFormFile file, int facilityId)
+        {
+            var result = await _service.UploadImageAsync(file, facilityId);
+            return Ok(result);
+        }
+
         private static FacilityResponseDto ToDto(Facility f)
         {
             return new FacilityResponseDto

--- a/KonferenscentrumVast/DTO/FileUploadResultDto.cs
+++ b/KonferenscentrumVast/DTO/FileUploadResultDto.cs
@@ -1,0 +1,11 @@
+using System;
+namespace KonferenscentrumVast.DTO
+{
+    //DTO for the file that is used for uploads and returns the filename, path and size.
+    public class FileUploadResultDto
+    {
+        public string FileName { get; set; } = string.Empty;
+        public string BlobPath { get; set; } = string.Empty;
+        public long Size { get; set; }
+    }
+}

--- a/KonferenscentrumVast/KonferenscentrumVast.csproj
+++ b/KonferenscentrumVast/KonferenscentrumVast.csproj
@@ -34,6 +34,7 @@
     <Folder Include="DTO\" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.25.1" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/KonferenscentrumVast/Program.cs
+++ b/KonferenscentrumVast/Program.cs
@@ -6,6 +6,8 @@ using KonferenscentrumVast.Exceptions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
 using System.Reflection;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -43,6 +45,11 @@ builder.Services.AddScoped<CustomerService>();
 // Database
 builder.Services.AddDbContext<ApplicationDbContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+// Azure Blob Storage
+builder.Services.AddSingleton(new BlobServiceClient(
+    builder.Configuration["Blob_ConnectionString"]
+    ?? builder.Configuration["AzureStorage:ConnectionString"]));
 
 builder.Services.AddCors(opt =>
 {

--- a/KonferenscentrumVast/Services/BookingContractService.cs
+++ b/KonferenscentrumVast/Services/BookingContractService.cs
@@ -3,6 +3,8 @@ using KonferenscentrumVast.DTO;
 using KonferenscentrumVast.Exceptions;
 using KonferenscentrumVast.Models;
 using KonferenscentrumVast.Repository.Interfaces;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
 
 namespace KonferenscentrumVast.Services
 {
@@ -17,19 +19,26 @@ namespace KonferenscentrumVast.Services
         private readonly IFacilityRepository _facilities;
         private readonly ICustomerRepository _customers;
         private readonly ILogger<BookingContractService> _logger;
+        private readonly BlobServiceClient _blob;
+        private readonly string _contractsContainer;
 
         public BookingContractService(
             IBookingRepository bookings,
             IBookingContractRepository contracts,
             IFacilityRepository facilities,
             ICustomerRepository customers,
-            ILogger<BookingContractService> logger)
+            ILogger<BookingContractService> logger,
+            BlobServiceClient blob,
+            IConfiguration cfg)
         {
             _bookings = bookings;
             _contracts = contracts;
             _facilities = facilities;
             _customers = customers;
             _logger = logger;
+            _blob = blob;
+            _contractsContainer = cfg["AzureStorage:ContractsContainer"] 
+                ?? throw new InvalidOperationException("Missing AzureStorage:ContractsContainer");
         }
 
         /// <summary>
@@ -195,6 +204,77 @@ namespace KonferenscentrumVast.Services
 
             _logger.LogInformation("Cancelled contract {ContractId}.", updated.Id);
             return updated;
+        }
+
+        /// <summary>
+        /// Handles contract file uploads by validating input, checking file type and size,
+        /// ensuring the contract exists, and then uploading the file to Azure Blob Storage.
+        /// Returns information about the uploaded file, including its path, name, and size.
+        /// </summary>
+
+        public async Task<FileUploadResultDto> UploadContractAsync(IFormFile file, int contractId)
+        {
+            //Validations for the id and the files
+            if (contractId <= 0)
+                throw new ValidationException("Invalid id.");
+
+            if (file == null || file.Length == 0)
+                throw new ValidationException("File is missing or empty.");
+
+            const long MaxBytes = 10 * 1024 * 1024; // 10 MB
+            if (file.Length > MaxBytes)
+                throw new ValidationException("File is too large.");
+
+            //Gets the contract with the contractId and checks if it exists
+            var contract = await _contracts.GetByIdAsync(contractId);
+
+            if (contract is null) throw new NotFoundException("Contract not found");
+
+            //If the ContentType/extension is null, use an empty string to prevent the app from crashing
+            // Convert them to small letters
+            var ct = (file.ContentType ?? "").ToLowerInvariant();
+            var ext = (Path.GetExtension(file.FileName) ?? "").ToLowerInvariant();
+
+            //Check if the file is PDF or DOCX
+            var okContract =
+                (ct == "application/pdf" && ext == ".pdf") ||
+                (ct == "application/vnd.openxmlformats-officedocument.wordprocessingml.document" && ext == ".docx");
+
+            if (!okContract) throw new ValidationException("Only PDF or DOCX is allowed.");
+
+            //Gets only the filename and creates a unique blob name under this id
+            var safeName = Path.GetFileName(file.FileName);
+            var blobName = $"{contractId}/{Guid.NewGuid()}_{safeName}";
+
+            //Gets the container and blob with the connection string
+            var container = _blob.GetBlobContainerClient(_contractsContainer);
+            var blob = container.GetBlobClient(blobName);
+
+            //Open the read stream and upload the blob
+            using var s = file.OpenReadStream();
+
+            await blob.UploadAsync(
+                s,
+                new BlobUploadOptions
+                {
+                    HttpHeaders = new BlobHttpHeaders
+                    {
+                        ContentType = file.ContentType ?? "application/octet-stream",
+                    },
+                }
+            );
+
+            _logger.LogInformation(
+                "Uploaded contract file {FileName} for contract id {ContractId} to container {Container} as {BlobName} ({SizedBytes} bytes).",
+                safeName, contractId, _contractsContainer, blobName, file.Length);
+
+            //Returns information about the uploaded file, including its path, name and size.
+            return new FileUploadResultDto
+            {
+                BlobPath = blobName,
+                FileName = safeName,
+                Size = file.Length,
+            };
         }
 
         /// <summary>

--- a/KonferenscentrumVast/Services/FacilityService.cs
+++ b/KonferenscentrumVast/Services/FacilityService.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+using KonferenscentrumVast.DTO;
 using KonferenscentrumVast.Exceptions;
 using KonferenscentrumVast.Models;
 using KonferenscentrumVast.Repository.Interfaces;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
 
 namespace KonferenscentrumVast.Services
 {
@@ -13,13 +16,20 @@ namespace KonferenscentrumVast.Services
     {
         private readonly IFacilityRepository _facilities;
         private readonly ILogger<FacilityService> _logger;
+        private readonly BlobServiceClient _blob;
+        private readonly string _imagesContainer;
 
         public FacilityService(
             IFacilityRepository facilities,
-            ILogger<FacilityService> logger)
+            ILogger<FacilityService> logger,
+            BlobServiceClient blob,
+            IConfiguration cfg)
         {
             _facilities = facilities;
             _logger = logger;
+            _blob = blob;
+            _imagesContainer = cfg["AzureStorage:ImagesContainer"]
+                ?? throw new InvalidOperationException("Missing AzureStorage:ImagesContainer");
         }
 
         public Task<IEnumerable<Facility>> GetAllAsync() => _facilities.GetAllAsync();
@@ -125,6 +135,77 @@ namespace KonferenscentrumVast.Services
 
             _logger.LogInformation("Set facility {FacilityId} active={Active}.", facility.Id, isActive);
             return updated;
+        }
+
+         /// <summary>
+        /// Handles image file uploads by validating input, checking file type and size,
+        /// ensuring the facility exists, and then uploading the file to Azure Blob Storage.
+        /// Returns information about the uploaded file, including its path, name, and size.
+        /// </summary>
+
+        public async Task<FileUploadResultDto> UploadImageAsync(IFormFile file, int facilityId)
+        {
+            //Validations for the id and the files
+            if (facilityId <= 0)
+                throw new ValidationException("Invalid id.");
+
+            if (file == null || file.Length == 0)
+                throw new ValidationException("File is missing or empty.");
+
+            const long MaxBytes = 10 * 1024 * 1024; // 10 MB
+            if (file.Length > MaxBytes)
+                throw new ValidationException("File is too large.");
+
+            //Gets the facility with the id and checks if it exists
+            var facility = await _facilities.GetByIdAsync(facilityId);
+
+            if (facility is null) throw new NotFoundException("Facility not found");
+
+            //If the ContentType/extension is null, use an empty string to prevent the app from crashing
+            // Convert them to small letters
+            var ct = (file.ContentType ?? "").ToLowerInvariant();
+            var ext = (Path.GetExtension(file.FileName) ?? "").ToLowerInvariant();
+
+            //Check if the file is JPG or PNG
+            var okImage =
+                (ct == "image/jpeg" && (ext == ".jpg" || ext == ".jpeg")) ||
+                (ct == "image/png" && ext == ".png");
+
+            if (!okImage) throw new ValidationException("Only JPG or PNG is allowed.");
+
+            //Gets only the filename and creates a unique blob name under this id
+            var safeName = Path.GetFileName(file.FileName);
+            var blobName = $"{facilityId}/{Guid.NewGuid()}_{safeName}";
+
+            //Gets the container and blob with the connection string
+            var container = _blob.GetBlobContainerClient(_imagesContainer);
+            var blob = container.GetBlobClient(blobName);
+
+            //Open the read stream and upload the blob
+            using var s = file.OpenReadStream();
+
+            await blob.UploadAsync(
+                s,
+                new BlobUploadOptions
+                {
+                    HttpHeaders = new BlobHttpHeaders
+                    {
+                        ContentType = file.ContentType ?? "application/octet-stream",
+                    },
+                }
+            );
+
+            _logger.LogInformation(
+                "Uploaded image file {FileName} for facility id {FacilityId} to container {Container} as {BlobName} ({SizedBytes} bytes).",
+                safeName, facilityId, _imagesContainer, blobName, file.Length);
+
+            //Returns information about the uploaded file, including its path, name and size.
+            return new FileUploadResultDto
+            {
+                BlobPath = blobName,
+                FileName = safeName,
+                Size = file.Length,
+            };
         }
 
         /// <summary>


### PR DESCRIPTION
Lade till stöd för att ladda upp bilder (JPG/PNG) och kontrakt (PDF/DOCX).  
Inkluderar validering av filtyp, filstorlek (10 MB) och säker lagring i Azure Blob Storage.  
Closes #6 